### PR TITLE
Fix formatting with simple quotes

### DIFF
--- a/src/Manialib/Formatting/Parser.php
+++ b/src/Manialib/Formatting/Parser.php
@@ -76,7 +76,7 @@ abstract class Parser implements ConverterInterface
             $value = $this->lexer->lookahead['value'];
             switch ($this->lexer->lookahead['type']) {
                 case Lexer::T_NONE:
-                    $this->none(htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8'));
+                    $this->none(htmlspecialchars($value, ENT_COMPAT | ENT_SUBSTITUTE, 'UTF-8'));
                     break;
                 case Lexer::T_ESCAPED_CHAR:
                     $this->escapedCharacter($value);

--- a/tests/HtmlTest.php
+++ b/tests/HtmlTest.php
@@ -11,6 +11,10 @@ class HtmlTest extends TestCase
     {
         return [
             [
+                'gou1\'s club',
+                'gou1\'s club',
+            ],
+            [
                 '$cfeg$fff๐u1 $666ツ',
                 '<span style="color:#cfe;">g</span><span style="color:#fff;">๐u1 </span><span style="color:#666;">ツ</span>'
             ],


### PR DESCRIPTION
cf https://stackoverflow.com/questions/16403858/htmlspecialchars-converting-apostrophe-to-amp039-for-facebook-ogtitle-tag  
thank you @gou1 