### PR TITLE
Upgrade doctrine/lexer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     },
     "require": {
         "php": "^7.1 || ^8.0",
-        "doctrine/lexer": "~1.0"
+        "doctrine/lexer": "^1.0 || ^2.0"
     },
     "require-dev": {
         "squizlabs/php_codesniffer": "@stable",


### PR DESCRIPTION
doctrine/lexer 1.x and 2.x are fully compatible. Array access on token are deprecated and should be removed before we use 3.0