### PR TITLE
Fix stripAll method

### DIFF
--- a/src/Manialib/Formatting/ManiaplanetString.php
+++ b/src/Manialib/Formatting/ManiaplanetString.php
@@ -68,7 +68,7 @@ class ManiaplanetString implements StringInterface
     {
         $this->string = preg_replace('/(?<!\$)((?:\$\$)*)\$[^$0-9a-fhlp\[\]]/iu', '$1', $this->string);
 
-        return $this->stripEscapeCharacters()->stripLinks()->stripColors();
+        return $this->stripLinks()->stripColors()->stripEscapeCharacters();
     }
 
     public function stripColors()

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -27,7 +27,7 @@ class StringTest extends TestCase
         return [
             ['$cfeg$fff๐u1 $666ツ', 'g๐u1 ツ'],
             ['$u$l[http://google.fr]google$l', 'google'],
-            ['$$l[ImAnIdiotTryingToAbuse]', '$$l[ImAnIdiotTryingToAbuse]'],
+            ['$$l[ImAnIdiotTryingToAbuse]', '$l[ImAnIdiotTryingToAbuse]'],
         ];
     }
 

--- a/tests/StringTest.php
+++ b/tests/StringTest.php
@@ -27,6 +27,7 @@ class StringTest extends TestCase
         return [
             ['$cfeg$fff๐u1 $666ツ', 'g๐u1 ツ'],
             ['$u$l[http://google.fr]google$l', 'google'],
+            ['$$l[ImAnIdiotTryingToAbuse]', '$$l[ImAnIdiotTryingToAbuse]'],
         ];
     }
 
@@ -58,6 +59,7 @@ class StringTest extends TestCase
     public function stripLinksProvider()
     {
         return [
+            ['$$l[ImAnIdiotTryingToAbuse]', '$$l[ImAnIdiotTryingToAbuse]'],
             ['$ltest$l', 'test'],
             ['$l[link]test$l', 'test'],
             ['$htest$h', 'test'],


### PR DESCRIPTION
When using `stripAll`, if we strip the escape characters before other function, `$$` get transformed in `$` so ecaped colors and link codes are not escaped anymore and stripped (while they shouldn't) 